### PR TITLE
Feature/allow duplicate option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default class Autocomplete extends Component {
 		enterKeys: [],
 		children: <input />,
 		saveOnBlur: false,
-		allowDuplicates: false,
+		allowDuplicates: true,
 		onKeyUp: ()=>{},
 		onKeyDown: ()=>{},
 		onAdd: ()=>{},

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,13 @@ const validateTagsLimit = (tags, limit) => {
 	return tags
 }
 
+const validateTagExist = (tags, tag) => {
+	if(tags.findIndex(t => t === tag) === -1) {
+		return false
+	}
+	return true
+}
+
 const TAG_SHAPE = PropTypes.shape({
 	label: PropTypes.string.isRequired,
 	value: PropTypes.string.isRequired,
@@ -39,6 +46,7 @@ export default class Autocomplete extends Component {
 		loaderPosition: PropTypes.oneOf(['top', 'bottom']),
 		children: PropTypes.node,
 		saveOnBlur: PropTypes.bool,
+		allowDuplicates: PropTypes.bool,
 		onKeyUp: PropTypes.func,
 		onKeyDown: PropTypes.func,
 		onAdd: PropTypes.func,
@@ -60,6 +68,7 @@ export default class Autocomplete extends Component {
 		enterKeys: [],
 		children: <input />,
 		saveOnBlur: false,
+		allowDuplicates: false,
 		onKeyUp: ()=>{},
 		onKeyDown: ()=>{},
 		onAdd: ()=>{},
@@ -240,22 +249,43 @@ export default class Autocomplete extends Component {
 	 */
 	onClickSuggestion = idx => {
 		const {label, value} = this.state.suggestions[idx]
-		this._addTag(label, value)
+		const {tags} = this.state
+		const {allowDuplicates} = this.props
+		if(!allowDuplicates) {
+			if(!validateTagExist(tags, label)) {
+				this._addTag(label, value)
+			}
+		} else {
+			this._addTag(label, value)
+		}
 	}
 
 	/* On enter we add a tag in state.tags */
 	_handleEnter = (ev, value) =>{
-		const { suggestions, focusedSuggestion } = this.state
-		const { allowCreateTag } = this.props
+		const { suggestions, focusedSuggestion, tags } = this.state
+		const { allowCreateTag, allowDuplicates } = this.props
 		const hasfocusedsuggestion = this.hasfocusedsuggestion()
 
 		if(allowCreateTag){
 			let tagToAdd = (!hasfocusedsuggestion) ? value : suggestions[focusedSuggestion].label
-			this._addTag(tagToAdd, value)
+			if(allowDuplicates) {
+				this._addTag(tagToAdd, value)
+			} else {
+				if(!validateTagExist(tags, tagToAdd)) {
+					this._addTag(tagToAdd, value)
+				}
+			}
 		}else{
 			if(hasfocusedsuggestion){
+				console.log('has focused suggestion')
 				const { label: labelToAdd, value: valueToAdd } = suggestions[focusedSuggestion]
-				this._addTag(labelToAdd, valueToAdd)
+				if(allowDuplicates) {
+					this._addTag(labelToAdd, valueToAdd)
+				} else {
+					if(!validateTagExist(tags, valueToAdd)) {
+						this._addTag(labelToAdd, valueToAdd)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
By default, duplicate tags are allowed, but in my use-case, I wanted to prevent duplicate entry so I added it as a component prop `allowDuplicates`, which still defaults to true.

My first open-source PR. Please let me know if this is a worthy contribution and if I need to make any additional changes. I also have filter and sort features (for suggestions) and also an autoShowSuggestions bool prop that can disable automatic pop-up of suggestions, if you'd like me to PR those as well, I would be more than happy!